### PR TITLE
Derive `Eq` on `ParseStringError`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "read_token"
-version = "0.0.12"
+version = "0.0.13"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["read", "parse", "token", "piston"]
 description = "A simple library to read tokens using look ahead"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub fn string(chars: &[char], offset: usize) -> Option<Range> {
 }
 
 /// Contains errors when parsing a string.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ParseStringError {
     /// Expected four hexadecimals, found less characters
     ExpectedFourHexadecimals(Range),


### PR DESCRIPTION
This is needed in piston-meta.
