### PR TITLE
Updated to latest range library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ name = "read_token"
 path = "src/lib.rs"
 
 [dependencies]
-range = "0.2.0"
+range = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "read_token"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["read", "parse", "token", "piston"]
 description = "A simple library to read tokens using look ahead"


### PR DESCRIPTION
Depends on https://github.com/PistonDevelopers/range/pull/34
- Bumped to 0.4.0
- Removed `Range` parameter of `ParseStringError`

TODO:
- [x] Update range version in Cargo.toml
