### PR TITLE
Redesign

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "read_token"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["read", "parse", "token", "piston"]
 description = "A simple library to read tokens using look ahead"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,12 +24,11 @@ impl<'a> ReadToken<'a> {
         }
     }
 
-    /// Consumes a range of characters.
-    pub fn consume(self, range: Range) -> ReadToken<'a> {
-        let next_offset = range.next_offset();
+    /// Consumes n characters.
+    pub fn consume(self, n: usize) -> ReadToken<'a> {
         ReadToken {
-            chars: &self.chars[next_offset - self.offset..],
-            offset: next_offset
+            chars: &self.chars[n..],
+            offset: self.offset + n
         }
     }
 
@@ -91,7 +90,7 @@ impl<'a> ReadToken<'a> {
                             // If it did, we do not require a new line before
                             // calling the closure.
                             new_lines = read_token.ended_with_newline(range);
-                            read_token = read_token.consume(range);
+                            read_token = read_token.consume(range.length);
                         }
                     }
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,14 +32,6 @@ impl<'a> ReadToken<'a> {
         }
     }
 
-    /// Take n characters for separate reading.
-    pub fn take(&self, n: usize) -> ReadToken<'a> {
-        ReadToken {
-            chars: &self.chars[..n],
-            offset: self.offset
-        }
-    }
-
     /// Reads a raw string.
     pub fn raw_string(&self, n: usize) -> String {
         let mut text = String::with_capacity(n);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ impl<'a> ReadToken<'a> {
     }
 
     /// Parses four unicode characters in hexadecimal format.
-    pub fn parse_unicode(&self) -> Result<char, Range<ParseStringError>> {
+    fn parse_unicode(&self) -> Result<char, Range<ParseStringError>> {
         use std::char;
 
         if self.chars.len() < 4 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use std::fmt::Error as FormatError;
 use range::Range;
 
 /// Stores the state of parsing.
+#[derive(Copy, Clone, Debug)]
 pub struct ReadToken<'a> {
     chars: &'a [char],
     offset: usize,
@@ -102,10 +103,7 @@ impl<'a> ReadToken<'a> {
     }
 
     /// Reads number.
-    pub fn number(
-        self,
-        settings: &NumberSettings,
-    ) -> Option<Range> {
+    pub fn number(&self, settings: &NumberSettings) -> Option<Range> {
         let mut has_sign = false;
         let mut has_decimal_separator = false;
         let mut has_scientific = false;
@@ -139,6 +137,238 @@ impl<'a> ReadToken<'a> {
         if self.chars.len() > 0 { return Some(self.peek(self.chars.len())); }
         else { return None }
     }
+
+    /// Parses four unicode characters in hexadecimal format.
+    pub fn parse_unicode(&self) -> Result<char, Range<ParseStringError>> {
+        use std::char;
+
+        if self.chars.len() < 4 {
+            return Err(Range::new(self.offset, self.chars.len())
+                .wrap(ParseStringError::ExpectedFourHexadecimals));
+        }
+
+        let mut u: [u32; 4] = [0; 4];
+        for (i, c) in u.iter_mut().enumerate() {
+            match self.chars[i].to_digit(16) {
+                Some(x) => *c = x as u32,
+                None => {
+                    return Err(Range::new(self.offset + i, 1)
+                        .wrap(ParseStringError::ExpectedHexadecimal))
+                }
+            }
+        }
+        let code = (u[0] << 12) | (u[1] << 8) | (u[2] << 4) | u[3];
+        match char::from_u32(code) {
+            Some(x) => Ok(x),
+            None => Err(Range::new(self.offset, 4)
+                .wrap(ParseStringError::ExpectedValidUnicode))
+        }
+    }
+
+    /// Parses string into a real string according to the JSON standard.
+    ///
+    /// Assumes the string starts and ends with double-quotes.
+    /// `offset` is the location at the start of the slice.
+    /// `next_offset` is the location where the string ends.
+    pub fn parse_string(&self, next_offset: usize)
+    -> Result<String, Range<ParseStringError>> {
+        let mut escape = false;
+        let length = next_offset - self.offset - 2;
+        let mut txt = String::with_capacity(length);
+        for (i, &c) in self.chars[1..length + 1].iter().enumerate() {
+            if c == '\\' { escape = true; continue; }
+            if escape {
+                escape = false;
+                txt.push(match c {
+                    '\"' => '"',
+                    '\\' => '\\',
+                    '/' => '/',
+                    'b' => '\u{0008}',
+                    'f' => '\u{000c}',
+                    'n' => '\n',
+                    'r' => '\r',
+                    't' => '\t',
+                    'u' => {
+                        let offset = self.offset + 1 + i;
+                        match ReadToken::new(&self.chars[offset..], offset)
+                            .parse_unicode() {
+                            Ok(x) => x,
+                            Err(err) => return Err(err)
+                        }
+                    }
+                    _ => {
+                        return Err(Range::new(self.offset + i + 1, 1)
+                            .wrap(ParseStringError::ExpectedValidEscapeCharacter));
+                    }
+                })
+            } else {
+                txt.push(c)
+            }
+        }
+        Ok(txt)
+    }
+
+    /// Parses number.
+    pub fn parse_number(&self, settings: &NumberSettings)
+    -> Result<f64, ParseNumberError> {
+        #[inline(always)]
+        fn slice_shift_char(src: &[char]) -> Option<(char, &[char])> {
+            if src.len() == 0 { None }
+            else { Some((src[0], &src[1..])) }
+        }
+
+        #[inline(always)]
+        fn parse_u64(settings: &NumberSettings, src: &[char]) -> Result<u64, ()> {
+            let mut res: u64 = 0;
+            for &c in src {
+                if settings.allow_underscore && c == '_' { continue; }
+                res *= 10;
+                if let Some(digit) = to_digit(c) {
+                    res += digit as u64;
+                } else {
+                    return Err(())
+                }
+            }
+            Ok(res)
+        }
+
+        #[inline(always)]
+        fn to_digit(c: char) -> Option<u32> {
+            if c >= '0' && c <= '9' { Some(c as u32 - '0' as u32) }
+            else { None }
+        }
+
+        let radix: u32 = 10;
+        let (is_positive, src) =  match slice_shift_char(self.chars) {
+            None => {
+                return Err(ParseNumberError::ExpectedDigits);
+            }
+            Some(('-', src)) if src.len() == 0 => {
+                return Err(ParseNumberError::ExpectedDigits);
+            }
+            Some(('-', src)) => (false, src),
+            Some((_, _))     => (true,  self.chars),
+        };
+
+        // The significand to accumulate
+        let mut sig = if is_positive { 0.0 } else { -0.0 };
+        // Necessary to detect overflow
+        let mut prev_sig = sig;
+        let mut cs = src.iter().enumerate();
+        // Exponent prefix and exponent index offset
+        let mut exp_info = None::<(char, usize)>;
+
+        // Parse the integer part of the significand
+        for (i, &c) in cs.by_ref() {
+            if settings.allow_underscore && c == '_' { continue; }
+            match to_digit(c) {
+                Some(digit) => {
+                    // shift significand one digit left
+                    sig = sig * (radix as f64);
+
+                    // add/subtract current digit depending on sign
+                    if is_positive {
+                        sig = sig + ((digit as isize) as f64);
+                    } else {
+                        sig = sig - ((digit as isize) as f64);
+                    }
+
+                    // Detect overflow by comparing to last value, except
+                    // if we've not seen any non-zero digits.
+                    if prev_sig != 0.0 {
+                        if is_positive && sig <= prev_sig
+                            { return Err(ParseNumberError::OverflowInfinity); }
+                        if !is_positive && sig >= prev_sig
+                            { return Err(ParseNumberError::OverflowNegInfinity); }
+
+                        // Detect overflow by reversing the shift-and-add process
+                        if is_positive && (prev_sig != (sig - digit as f64) / radix as f64)
+                            { return Err(ParseNumberError::OverflowInfinity); }
+                        if !is_positive && (prev_sig != (sig + digit as f64) / radix as f64)
+                            { return Err(ParseNumberError::OverflowNegInfinity); }
+                    }
+                    prev_sig = sig;
+                },
+                None => match c {
+                    'e' | 'E' | 'p' | 'P' => {
+                        exp_info = Some((c, i + 1));
+                        break;  // start of exponent
+                    },
+                    '.' => {
+                        break;  // start of fractional part
+                    },
+                    _ => {
+                        return Err(ParseNumberError::Invalid);
+                    },
+                },
+            }
+        }
+
+        // If we are not yet at the exponent parse the fractional
+        // part of the significand
+        if exp_info.is_none() {
+            let mut power = 1.0;
+            for (i, &c) in cs.by_ref() {
+                if settings.allow_underscore && c == '_' { continue; }
+                match to_digit(c) {
+                    Some(digit) => {
+                        // Decrease power one order of magnitude
+                        power = power / (radix as f64);
+                        // add/subtract current digit depending on sign
+                        sig = if is_positive {
+                            sig + (digit as f64) * power
+                        } else {
+                            sig - (digit as f64) * power
+                        };
+                        // Detect overflow by comparing to last value
+                        if is_positive && sig < prev_sig
+                            { return Err(ParseNumberError::OverflowInfinity); }
+                        if !is_positive && sig > prev_sig
+                            { return Err(ParseNumberError::OverflowNegInfinity); }
+                        prev_sig = sig;
+                    },
+                    None => match c {
+                        'e' | 'E' | 'p' | 'P' => {
+                            exp_info = Some((c, i + 1));
+                            break; // start of exponent
+                        },
+                        _ => {
+                            return Err(ParseNumberError::Invalid);
+                        },
+                    },
+                }
+            }
+        }
+
+        // Parse and calculate the exponent
+        let exp = match exp_info {
+            Some((c, offset)) => {
+                let base = match c {
+                    'E' | 'e' if radix == 10 => 10.0,
+                    _ => return Err(ParseNumberError::Invalid),
+                };
+
+                // Parse the exponent as decimal integer
+                let src = &src[offset..];
+                let (is_positive, exp) = match slice_shift_char(src) {
+                    Some(('-', src)) => (false, parse_u64(settings, src)),
+                    Some(('+', src)) => (true,  parse_u64(settings, src)),
+                    Some((_, _))     => (true,  parse_u64(settings, src)),
+                    None             => return Err(ParseNumberError::Invalid),
+                };
+
+                match (is_positive, exp) {
+                    (true,  Ok(exp)) => f64::powi(base, exp as i32),
+                    (false, Ok(exp)) => 1.0 / base.powi(exp as i32),
+                    (_, Err(_))      => return Err(ParseNumberError::Invalid),
+                }
+            },
+            None => 1.0, // no exponent
+        };
+
+        Ok(sig * exp)
+
+    }
 }
 
 /// Contains errors when parsing a string.
@@ -167,81 +397,6 @@ impl Display for ParseStringError {
                 fmt.write_str("Expected valid escape character '\"\\/bfnrtu'"),
         }
     }
-}
-
-/// Parses four unicode characters in hexadecimal format.
-pub fn parse_unicode(
-    chars: &[char],
-    offset: usize
-) -> Result<char, Range<ParseStringError>> {
-    use std::char;
-
-    if chars.len() < 4 {
-        return Err(Range::new(offset, chars.len())
-            .wrap(ParseStringError::ExpectedFourHexadecimals));
-    }
-
-    let mut u: [u32; 4] = [0; 4];
-    for (i, c) in u.iter_mut().enumerate() {
-        match chars[i].to_digit(16) {
-            Some(x) => *c = x as u32,
-            None => {
-                return Err(Range::new(offset + i, 1)
-                    .wrap(ParseStringError::ExpectedHexadecimal))
-            }
-        }
-    }
-    let code = (u[0] << 12) | (u[1] << 8) | (u[2] << 4) | u[3];
-    match char::from_u32(code) {
-        Some(x) => Ok(x),
-        None => Err(Range::new(offset, 4)
-            .wrap(ParseStringError::ExpectedValidUnicode))
-    }
-}
-
-/// Parses string into a real string according to the JSON standard.
-///
-/// Assumes the string starts and ends with double-quotes.
-/// `offset` is the location at the start of the slice.
-/// `next_offset` is the location where the string ends.
-pub fn parse_string(
-    chars: &[char],
-    offset: usize,
-    next_offset: usize,
-) -> Result<String, Range<ParseStringError>> {
-    let mut escape = false;
-    let length = next_offset - offset - 2;
-    let mut txt = String::with_capacity(length);
-    for (i, &c) in chars[1..length + 1].iter().enumerate() {
-        if c == '\\' { escape = true; continue; }
-        if escape {
-            escape = false;
-            txt.push(match c {
-                '\"' => '"',
-                '\\' => '\\',
-                '/' => '/',
-                'b' => '\u{0008}',
-                'f' => '\u{000c}',
-                'n' => '\n',
-                'r' => '\r',
-                't' => '\t',
-                'u' => {
-                    let offset = offset + 1 + i;
-                    match parse_unicode(&chars[offset..], offset) {
-                        Ok(x) => x,
-                        Err(err) => return Err(err)
-                    }
-                }
-                _ => {
-                    return Err(Range::new(offset + i + 1, 1)
-                        .wrap(ParseStringError::ExpectedValidEscapeCharacter));
-                }
-            })
-        } else {
-            txt.push(c)
-        }
-    }
-    Ok(txt)
 }
 
 /// The settings for reading numbers.
@@ -277,170 +432,6 @@ impl Display for ParseNumberError {
                 fmt.write_str("Number overflowed toward negative infinity"),
         }
     }
-}
-
-/// Parses number.
-pub fn parse_number(
-    settings: &NumberSettings,
-    src: &[char]
-) -> Result<f64, ParseNumberError> {
-    #[inline(always)]
-    fn slice_shift_char(src: &[char]) -> Option<(char, &[char])> {
-        if src.len() == 0 { None }
-        else { Some((src[0], &src[1..])) }
-    }
-
-    #[inline(always)]
-    fn parse_u64(settings: &NumberSettings, src: &[char]) -> Result<u64, ()> {
-        let mut res: u64 = 0;
-        for &c in src {
-            if settings.allow_underscore && c == '_' { continue; }
-            res *= 10;
-            if let Some(digit) = to_digit(c) {
-                res += digit as u64;
-            } else {
-                return Err(())
-            }
-        }
-        Ok(res)
-    }
-
-    #[inline(always)]
-    fn to_digit(c: char) -> Option<u32> {
-        if c >= '0' && c <= '9' { Some(c as u32 - '0' as u32) }
-        else { None }
-    }
-
-    let radix: u32 = 10;
-    let (is_positive, src) =  match slice_shift_char(src) {
-        None => {
-            return Err(ParseNumberError::ExpectedDigits);
-        }
-        Some(('-', src)) if src.len() == 0 => {
-            return Err(ParseNumberError::ExpectedDigits);
-        }
-        Some(('-', src)) => (false, src),
-        Some((_, _))     => (true,  src),
-    };
-
-    // The significand to accumulate
-    let mut sig = if is_positive { 0.0 } else { -0.0 };
-    // Necessary to detect overflow
-    let mut prev_sig = sig;
-    let mut cs = src.iter().enumerate();
-    // Exponent prefix and exponent index offset
-    let mut exp_info = None::<(char, usize)>;
-
-    // Parse the integer part of the significand
-    for (i, &c) in cs.by_ref() {
-        if settings.allow_underscore && c == '_' { continue; }
-        match to_digit(c) {
-            Some(digit) => {
-                // shift significand one digit left
-                sig = sig * (radix as f64);
-
-                // add/subtract current digit depending on sign
-                if is_positive {
-                    sig = sig + ((digit as isize) as f64);
-                } else {
-                    sig = sig - ((digit as isize) as f64);
-                }
-
-                // Detect overflow by comparing to last value, except
-                // if we've not seen any non-zero digits.
-                if prev_sig != 0.0 {
-                    if is_positive && sig <= prev_sig
-                        { return Err(ParseNumberError::OverflowInfinity); }
-                    if !is_positive && sig >= prev_sig
-                        { return Err(ParseNumberError::OverflowNegInfinity); }
-
-                    // Detect overflow by reversing the shift-and-add process
-                    if is_positive && (prev_sig != (sig - digit as f64) / radix as f64)
-                        { return Err(ParseNumberError::OverflowInfinity); }
-                    if !is_positive && (prev_sig != (sig + digit as f64) / radix as f64)
-                        { return Err(ParseNumberError::OverflowNegInfinity); }
-                }
-                prev_sig = sig;
-            },
-            None => match c {
-                'e' | 'E' | 'p' | 'P' => {
-                    exp_info = Some((c, i + 1));
-                    break;  // start of exponent
-                },
-                '.' => {
-                    break;  // start of fractional part
-                },
-                _ => {
-                    return Err(ParseNumberError::Invalid);
-                },
-            },
-        }
-    }
-
-    // If we are not yet at the exponent parse the fractional
-    // part of the significand
-    if exp_info.is_none() {
-        let mut power = 1.0;
-        for (i, &c) in cs.by_ref() {
-            if settings.allow_underscore && c == '_' { continue; }
-            match to_digit(c) {
-                Some(digit) => {
-                    // Decrease power one order of magnitude
-                    power = power / (radix as f64);
-                    // add/subtract current digit depending on sign
-                    sig = if is_positive {
-                        sig + (digit as f64) * power
-                    } else {
-                        sig - (digit as f64) * power
-                    };
-                    // Detect overflow by comparing to last value
-                    if is_positive && sig < prev_sig
-                        { return Err(ParseNumberError::OverflowInfinity); }
-                    if !is_positive && sig > prev_sig
-                        { return Err(ParseNumberError::OverflowNegInfinity); }
-                    prev_sig = sig;
-                },
-                None => match c {
-                    'e' | 'E' | 'p' | 'P' => {
-                        exp_info = Some((c, i + 1));
-                        break; // start of exponent
-                    },
-                    _ => {
-                        return Err(ParseNumberError::Invalid);
-                    },
-                },
-            }
-        }
-    }
-
-    // Parse and calculate the exponent
-    let exp = match exp_info {
-        Some((c, offset)) => {
-            let base = match c {
-                'E' | 'e' if radix == 10 => 10.0,
-                _ => return Err(ParseNumberError::Invalid),
-            };
-
-            // Parse the exponent as decimal integer
-            let src = &src[offset..];
-            let (is_positive, exp) = match slice_shift_char(src) {
-                Some(('-', src)) => (false, parse_u64(settings, src)),
-                Some(('+', src)) => (true,  parse_u64(settings, src)),
-                Some((_, _))     => (true,  parse_u64(settings, src)),
-                None             => return Err(ParseNumberError::Invalid),
-            };
-
-            match (is_positive, exp) {
-                (true,  Ok(exp)) => f64::powi(base, exp as i32),
-                (false, Ok(exp)) => 1.0 / base.powi(exp as i32),
-                (_, Err(_))      => return Err(ParseNumberError::Invalid),
-            }
-        },
-        None => 1.0, // no exponent
-    };
-
-    Ok(sig * exp)
-
 }
 
 #[cfg(test)]
@@ -495,20 +486,23 @@ mod tests {
         let text = "\"hello\"".chars().collect::<Vec<char>>();
         let res = ReadToken::new(&text, 0).string();
         assert_eq!(res, Some(Range::new(0, 7)));
-        let txt = parse_string(&text, 0, res.unwrap().next_offset()).ok().unwrap();
+        let txt = ReadToken::new(&text, 0)
+            .parse_string(res.unwrap().next_offset()).ok().unwrap();
         assert_eq!(txt, "hello");
 
         let text = "\"he\\\"llo\"".chars().collect::<Vec<char>>();
         let res = ReadToken::new(&text, 0).string();
         assert_eq!(res, Some(Range::new(0, 9)));
-        let txt = parse_string(&text, 0, res.unwrap().next_offset());
+        let txt = ReadToken::new(&text, 0)
+            .parse_string(res.unwrap().next_offset());
         let txt = txt.ok().unwrap();
         assert_eq!(txt, "he\"llo");
 
         let text = "\"he\"llo\"".chars().collect::<Vec<char>>();
         let res = ReadToken::new(&text, 0).string();
         assert_eq!(res, Some(Range::new(0, 4)));
-        let txt = parse_string(&text, 0, res.unwrap().next_offset());
+        let txt = ReadToken::new(&text, 0)
+            .parse_string(res.unwrap().next_offset());
         let txt = txt.ok().unwrap();
         assert_eq!(txt, "he");
 
@@ -523,19 +517,25 @@ mod tests {
 
         let to_chars = |s: &str| s.chars().collect::<Vec<char>>();
 
-        let res: f64 = parse_number(&settings, &to_chars("20")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("20"), 0)
+            .parse_number(&settings).unwrap();
         assert_eq!(res, 20.0);
-        let res: f64 = parse_number(&settings, &to_chars("-20")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("-20"), 0)
+            .parse_number(&settings).unwrap();
         assert_eq!(res, -20.0);
-        let res: f64 = parse_number(&settings, &to_chars("2e2")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("2e2"), 0)
+            .parse_number(&settings).unwrap();
         assert_eq!(res, 2e2);
-        let res: f64 = parse_number(&settings, &to_chars("2.5")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("2.5"), 0)
+            .parse_number(&settings).unwrap();
         assert_eq!(res, 2.5);
         let res: f64 = "2.5e2".parse().unwrap();
         assert_eq!(res, 2.5e2);
-        let res: f64 = parse_number(&settings, &to_chars("2.5E2")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("2.5E2"), 0)
+            .parse_number(&settings).unwrap();
         assert_eq!(res, 2.5E2);
-        let res: f64 = parse_number(&settings, &to_chars("2.5E-2")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("2.5E-2"), 0)
+            .parse_number(&settings).unwrap();
         assert_eq!(res, 2.5E-2);
 
         let text = "20".chars().collect::<Vec<char>>();
@@ -573,19 +573,26 @@ mod tests {
 
         let to_chars = |s: &str| s.chars().collect::<Vec<char>>();
 
-        let res: f64 = parse_number(&settings, &to_chars("2_0")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("2_0"), 0)
+            .parse_number(&settings, ).unwrap();
         assert_eq!(res, 20.0);
-        let res: f64 = parse_number(&settings, &to_chars("-2_0")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("-2_0"), 0)
+            .parse_number(&settings).unwrap();
         assert_eq!(res, -20.0);
-        let res: f64 = parse_number(&settings, &to_chars("2_e2_")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("2_e2_"), 0)
+            .parse_number(&settings).unwrap();
         assert_eq!(res, 2e2);
-        let res: f64 = parse_number(&settings, &to_chars("2_.5_")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("2_.5_"), 0)
+            .parse_number(&settings).unwrap();
         assert_eq!(res, 2.5);
-        let res: f64 = parse_number(&settings, &to_chars("2_.5_e2_")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("2_.5_e2_"), 0)
+            .parse_number(&settings).unwrap();
         assert_eq!(res, 2.5e2);
-        let res: f64 = parse_number(&settings, &to_chars("2_.5_E2_")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("2_.5_E2_"), 0)
+            .parse_number(&settings).unwrap();
         assert_eq!(res, 2.5E2);
-        let res: f64 = parse_number(&settings, &to_chars("2_.5_E-2_")).unwrap();
+        let res: f64 = ReadToken::new(&to_chars("2_.5_E-2_"), 0)
+            .parse_number(&settings).unwrap();
         assert_eq!(res, 2.5E-2);
 
         let text = "20".chars().collect::<Vec<char>>();


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/read_token/issues/34 
- Renamed `token` to `tag`
- Added `consume`, `raw_string`, `lines`, `subtract`, `start`
- Made `parse_number` and `parse_string` take `n: usize` for number of characters
- Bumped to 0.5.0

Notice that `parse_string` took `next_offset: usize` before, which changes to `n: usize`. Use `range.length` instead of `range.next_offset()`.
