### PR TITLE
Use `&str` in `ReadToken`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "read_token"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["read", "parse", "token", "piston"]
 description = "A simple library to read tokens using look ahead"


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/read_token/issues/37
- Bumped to 0.6.0
- Added unicode tests
