### PR TITLE
Number can not start with "e" or "E"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "read_token"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["read", "parse", "token", "piston"]
 description = "A simple library to read tokens using look ahead"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ impl<'a> ReadToken<'a> {
                 has_decimal_separator = true;
                 continue;
             }
-            if !has_scientific && (c == 'e' || c == 'E') {
+            if !has_scientific && (c == 'e' || c == 'E') && i > 0 {
                 has_scientific = true;
                 continue;
             }
@@ -505,7 +505,7 @@ impl Display for ParseStringError {
 }
 
 /// The settings for reading numbers.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct NumberSettings {
     /// Whether to allow underscore in number.
     pub allow_underscore: bool,
@@ -693,6 +693,12 @@ mod tests {
         let text = "2.5E-2";
         let res = ReadToken::new(&text, 0).number(&settings);
         assert_eq!(res, Some(Range::new(0, 6)));
+
+        let text = "e";
+        let res = ReadToken::new(&text, 0).number(&settings);
+        assert_eq!(res, None);
+        let res = ReadToken::new(&text, 0).parse_number(&settings, 1);
+        assert_eq!(res, Err(ParseNumberError::Invalid))
     }
 
     #[test]


### PR DESCRIPTION
- Bumped to 0.8.0
- Derive `PartialEq`, `Eq` on `NumberSettings`